### PR TITLE
Remove gcc-9-base package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,7 @@ RUN chown -R dragon: /ansible /share /archive
 RUN apt-get clean \
     && apt-get remove -y  \
       build-essential \
+      gcc-9-base \
       git \
       libffi-dev \
       libssl-dev \


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>