### PR TITLE
Remove mitogen 0.2.9 plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ ARG UBUNTU_VERSION=20.04
 FROM ubuntu:${UBUNTU_VERSION}
 
 ARG VERSION
-ARG MITOGEN_VERSION=0.2.9
 
 ARG USER_ID=45000
 ARG GROUP_ID=45000
@@ -124,18 +123,6 @@ RUN ansible-galaxy role install -v -f -r /ansible/requirements.yml -p /usr/share
     && ln -s /usr/share/ansible/roles /ansible/galaxy \
     && ansible-galaxy collection install -v -f -r /ansible/requirements.yml -p /usr/share/ansible/collections \
     && ln -s /usr/share/ansible/collections /ansible/collections
-
-# install required ansible plugins
-
-ADD https://github.com/dw/mitogen/archive/v$MITOGEN_VERSION.tar.gz /mitogen.tar.gz
-RUN tar xzf /mitogen.tar.gz --strip-components=1 -C /ansible/plugins/mitogen \
-    && rm -rf \
-        /ansible/plugins/mitogen/tests \
-        /ansible/plugins/mitogen/docs \
-        /ansible/plugins/mitogen/.ci \
-        /ansible/plugins/mitogen/.lgtm.yml \
-        /ansible/plugins/mitogen/.travis.yml \
-    && rm /mitogen.tar.gz
 
 # project specific instructions
 


### PR DESCRIPTION
Ansible 2.10 support is still missing.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>