### PR TITLE
github: remove trivy scanner

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -44,17 +44,6 @@ jobs:
           GIT_SHA: ${{ github.sha }}
           REPOSITORY: osism/osism-ansible
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          # yamllint disable-line rule:line-length
-          image-ref: '${{ secrets.DOCKER_REGISTRY }}/osism/osism-ansible:${{ github.sha }}'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-
       - name: Push docker image
         run: |
           scripts/push.sh


### PR DESCRIPTION
Images are now scanned on the Harbor.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>