### PR TITLE
Install iputils-ping packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -57,6 +57,7 @@ RUN apt-get update \
       dumb-init \
       git \
       gnupg-agent \
+      iputils-ping \
       libffi-dev \
       libssl-dev \
       libyaml-dev \


### PR DESCRIPTION
Necessary to execute ping to check if single nodes are reachable.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>