### PR TITLE
Install hiredis

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -12,6 +12,7 @@ asn1crypto
 celery[redis]==5.2.0
 cryptography
 debops
+hiredis
 hvac
 idna
 openstacksdk==0.52


### PR DESCRIPTION
UserWarning: redis-py works best with hiredis.

Signed-off-by: Christian Berendt <berendt@osism.tech>