### PR TITLE
Install kolla-ansible

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -15,6 +15,7 @@ debops
 hiredis
 hvac
 idna
+kolla-ansible==12.2.0
 openstacksdk==0.52
 paramiko
 proxmoxer


### PR DESCRIPTION
This is required to be able to use the kolla_address filter plugin

Signed-off-by: Christian Berendt <berendt@osism.tech>