### PR TITLE
Ignore the ansible.cfg in the manager environment

### DIFF
--- a/files/scripts/run-manager.sh
+++ b/files/scripts/run-manager.sh
@@ -24,9 +24,6 @@ fi
 export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
-if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
-    export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
-fi
 
 if [[ -w $ANSIBLE_INVENTORY ]]; then
     rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/


### PR DESCRIPTION
The ansible.cfg in the manager environment should only
be used if the local run.sh script is used in the manager
environment.

Signed-off-by: Christian Berendt <berendt@osism.tech>