### PR TITLE
Remove rsync from the scripts

### DIFF
--- a/files/scripts/run-ansible.sh
+++ b/files/scripts/run-ansible.sh
@@ -28,15 +28,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$environment/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$environment/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$environment
 
 ansible \

--- a/files/scripts/run-custom.sh
+++ b/files/scripts/run-custom.sh
@@ -28,15 +28,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
 
 ansible-playbook \

--- a/files/scripts/run-generic.sh
+++ b/files/scripts/run-generic.sh
@@ -28,15 +28,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
 
 if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/playbook-$service.yml ]]; then

--- a/files/scripts/run-infrastructure.sh
+++ b/files/scripts/run-infrastructure.sh
@@ -28,15 +28,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
 
 if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/playbook-$service.yml ]]; then

--- a/files/scripts/run-manager.sh
+++ b/files/scripts/run-manager.sh
@@ -25,15 +25,6 @@ export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
 
 if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/playbook-$service.yml ]]; then

--- a/files/scripts/run-monitoring.sh
+++ b/files/scripts/run-monitoring.sh
@@ -28,15 +28,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
 
 if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/playbook-$service.yml ]]; then

--- a/files/scripts/run-openstack.sh
+++ b/files/scripts/run-openstack.sh
@@ -28,15 +28,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
 
 if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/playbook-$service.yml ]]; then

--- a/files/scripts/run-state.sh
+++ b/files/scripts/run-state.sh
@@ -28,15 +28,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
 
 ansible-playbook \

--- a/files/scripts/run-validate.sh
+++ b/files/scripts/run-validate.sh
@@ -28,15 +28,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
 
 ansible-playbook \

--- a/files/scripts/run-without-secrets.sh
+++ b/files/scripts/run-without-secrets.sh
@@ -28,15 +28,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$environment/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$environment/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$environment
 
 if [[ -e playbook-$service.yml ]]; then

--- a/files/scripts/run.sh
+++ b/files/scripts/run.sh
@@ -31,15 +31,6 @@ if [[ -e $ENVIRONMENTS_DIRECTORY/$environment/ansible.cfg ]]; then
     export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$environment/ansible.cfg
 fi
 
-if [[ -w $ANSIBLE_INVENTORY ]]; then
-    rsync -a /ansible/group_vars/ /ansible/inventory/group_vars/
-    rsync -a /ansible/inventory.generics/ /ansible/inventory/
-    rsync -a /opt/configuration/inventory/ /ansible/inventory/
-    python3 /src/handle-inventory-overwrite.py
-    cat /ansible/inventory/[0-9]* > /ansible/inventory/hosts
-    rm /ansible/inventory/[0-9]*
-fi
-
 cd $ENVIRONMENTS_DIRECTORY/$environment
 
 ansible-playbook \


### PR DESCRIPTION
The rsync in the scripts has been used so far when the inventory
reconciler is not available as a service.

Since the inventory reconciler has been mandatory deployed for some
time now, the rsync in the scripts is no longer required and can
be removed.

Signed-off-by: Christian Berendt <berendt@osism.tech>