### PR TITLE
Install missing packages

### DIFF
--- a/files/src/requirements.txt
+++ b/files/src/requirements.txt
@@ -1,4 +1,6 @@
 Jinja2==3.0.3
 PyYAML==6.0
+neutron-dynamic-routing==20.0.0
 pottery==3.0.0
+python-designateclient==4.5.0
 yq==2.14.0


### PR DESCRIPTION
Those packages are required to be able to use zone
and bgp modules.

```
dragon@5f1790f4aed7:~$ openstack zone
openstack: 'zone' is not an openstack command. See 'openstack --help'.
Did you mean one of these?
  token issue
  token revoke
dragon@5f1790f4aed7:~$ openstack bgp
openstack: 'bgp' is not an openstack command. See 'openstack --help'.
Did you mean one of these?
  help
  ip availability list
  ip availability show
```

Closes #209

Signed-off-by: Christian Berendt <berendt@osism.tech>