### PR TITLE
Fix requirements for openstack client

### DIFF
--- a/files/src/requirements.txt
+++ b/files/src/requirements.txt
@@ -1,6 +1,6 @@
 Jinja2==3.1.2
 PyYAML==6.0
-neutron-dynamic-routing==20.0.0
 pottery==3.0.0
 python-designateclient==4.5.1
+python-neutronclient==7.8.0
 yq==2.14.0


### PR DESCRIPTION
The openstack bgp commands are provided by the python-neutronclient
plugin, not by the neutron-dynamic-routing package. The former is
implicitly being installed via python-designateclient already, but
better be explicit about this.

Related-to: #253

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>