### PR TITLE
Revert "Use 3.11-slim as base image (#259)"

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 ARG RELEASE_RECEPTOR=1.0.0
 FROM quay.io/project-receptor/receptor:${RELEASE_RECEPTOR} as receptor
 
-FROM python:3.11.0-slim
+FROM python:3.10-slim
 
 ARG VERSION=latest
 ARG IS_RELEASE=false


### PR DESCRIPTION
This reverts commit 93ab8e878b6ea5a4d5e27ef09d2a510cd2fce80b.

The OpenStack SDK is not yet happy with Python 3.11:

AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?

More details: https://github.com/pyinvoke/invoke/issues/833

Closes osism/issues#392