### PR TITLE
Add run-ceph.sh & run-kolla.sh

### DIFF
--- a/files/scripts/run-ceph.sh
+++ b/files/scripts/run-ceph.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+source /secrets.sh
+
+ENVIRONMENT=ceph
+
+if [[ $# -lt 1 ]]; then
+    echo usage: osism-$ENVIRONMENT SERVICE [...]
+    exit 1
+fi
+
+service=$1
+shift
+
+ANSIBLE_DIRECTORY=/ansible
+CONFIGURATION_DIRECTORY=/opt/configuration
+ENVIRONMENTS_DIRECTORY=$CONFIGURATION_DIRECTORY/environments
+VAULT=${VAULT:-$ENVIRONMENTS_DIRECTORY/.vault_pass}
+
+if [[ -e /ansible/ara.env ]]; then
+    source /ansible/ara.env
+fi
+
+export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory
+
+export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
+if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
+    export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
+fi
+
+cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
+
+if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/playbook-$service.yml ]]; then
+    ansible-playbook \
+      --vault-password-file $VAULT \
+      -e @$ENVIRONMENTS_DIRECTORY/configuration.yml \
+      -e @$ENVIRONMENTS_DIRECTORY/secrets.yml \
+      -e @secrets.yml \
+      -e @images.yml \
+      -e @configuration.yml \
+      "$@" \
+      playbook-$service.yml
+elif [[ -e $ANSIBLE_DIRECTORY/$ENVIRONMENT/$service.yml ]]; then
+    ansible-playbook \
+      --vault-password-file $VAULT \
+      -e @$ENVIRONMENTS_DIRECTORY/configuration.yml \
+      -e @$ENVIRONMENTS_DIRECTORY/secrets.yml \
+      -e @secrets.yml \
+      -e @images.yml \
+      -e @configuration.yml \
+      "$@" \
+      $ANSIBLE_DIRECTORY/$ENVIRONMENT/$service.yml
+else
+    echo "ERROR: service $service in environment $ENVIRONMENT not available"
+    exit 1
+fi

--- a/files/scripts/run-kolla.sh
+++ b/files/scripts/run-kolla.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+source /secrets.sh
+
+ENVIRONMENT=kolla
+
+if [[ $# -lt 1 ]]; then
+    echo usage: osism-$ENVIRONMENT SERVICE [...]
+    exit 1
+fi
+
+service=$1
+shift
+
+ANSIBLE_DIRECTORY=/ansible
+CONFIGURATION_DIRECTORY=/opt/configuration
+ENVIRONMENTS_DIRECTORY=$CONFIGURATION_DIRECTORY/environments
+VAULT=${VAULT:-$ENVIRONMENTS_DIRECTORY/.vault_pass}
+
+if [[ -e /ansible/ara.env ]]; then
+    source /ansible/ara.env
+fi
+
+export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory
+
+export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
+if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
+    export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
+fi
+
+cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
+
+if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/playbook-$service.yml ]]; then
+    ansible-playbook \
+      --vault-password-file $VAULT \
+      -e @$ENVIRONMENTS_DIRECTORY/configuration.yml \
+      -e @$ENVIRONMENTS_DIRECTORY/secrets.yml \
+      -e @secrets.yml \
+      -e @images.yml \
+      -e @configuration.yml \
+      "$@" \
+      playbook-$service.yml
+elif [[ -e $ANSIBLE_DIRECTORY/$ENVIRONMENT/$service.yml ]]; then
+    ansible-playbook \
+      --vault-password-file $VAULT \
+      -e @$ENVIRONMENTS_DIRECTORY/configuration.yml \
+      -e @$ENVIRONMENTS_DIRECTORY/secrets.yml \
+      -e @secrets.yml \
+      -e @images.yml \
+      -e @configuration.yml \
+      "$@" \
+      $ANSIBLE_DIRECTORY/$ENVIRONMENT/$service.yml
+else
+    echo "ERROR: service $service in environment $ENVIRONMENT not available"
+    exit 1
+fi


### PR DESCRIPTION
Required to be able to run the validation playbooks in the corresponing environmens without having to run them in the ceph-ansible or kolla-ansible containers.

Signed-off-by: Christian Berendt <berendt@osism.tech>