### PR TITLE
Remove zabbix, proxmox & junos requirements

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -17,7 +17,6 @@ hvac==0.11.2
 idna==3.4
 openstacksdk==0.61.0
 paramiko==2.12.0
-proxmoxer==1.3.0
 PyMySQL==1.0.2
 pynetbox==6.6.2
 python-dotenv==0.21.0
@@ -26,6 +25,4 @@ redis==4.4.0
 requests==2.28.1
 ruamel.yaml==0.17.21
 shade==1.33.0
-zabbix-api==0.5.4
-junos-eznc==2.6.3
 jxmlease==1.0.3


### PR DESCRIPTION
Zabbix, Proxmox & Juniper support were dropped some time ago.

Signed-off-by: Christian Berendt <berendt@osism.tech>