### PR TITLE
Do not install vim

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -57,7 +57,6 @@ RUN apt-get update \
       procps \
       rsync \
       sshpass \
-      vim-tiny \
     && update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3 1 \
     && update-alternatives --install /usr/bin/python python /usr/local/bin/python 1 \
     && python3 -m pip install --no-cache-dir --upgrade 'pip==22.3.1' \


### PR DESCRIPTION
vim was sometimes used for debugging, troubleshooting, etc. In future, dedicated development images should be used for this, but such tools should not be included in the final images.

Signed-off-by: Christian Berendt <berendt@osism.tech>