### PR TITLE
Render playbooks

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -179,6 +179,9 @@ RUN cp -r /playbooks/playbooks/* /ansible \
 # hadolint ignore=DL3059
 RUN python3 -m ara.setup.env > /ansible/ara.env
 
+# prepare list of playbooks
+RUN python3 /src/render-playbooks.py
+
 # set correct permssions
 # hadolint ignore=DL3059
 RUN chown -R dragon: /ansible /share /archive /interface

--- a/files/scripts/entrypoint.sh
+++ b/files/scripts/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-mkdir -p /interface/osism-ansible /interface/versions
+mkdir -p /interface/osism-ansible /interface/versions /interface/playbooks
 rsync -am --exclude='requirements*.yml' --include='*.yml' --exclude='*' /ansible/ /interface/osism-ansible/
 cp /ansible/group_vars/all/versions.yml /interface/versions/osism-ansible.yml
+cp /ansible/playbooks.yml /interface/playbooks/osism-ansible.yml
 
 exec /usr/bin/dumb-init -- "$@"

--- a/files/src/render-playbooks.py
+++ b/files/src/render-playbooks.py
@@ -1,0 +1,22 @@
+# This script writes a list of all existing playbooks to /ansible/playbooks.yml.
+
+from pathlib import Path
+
+import yaml
+
+PREFIXES = [
+    "generic",
+    "manager",
+    "monitoring",
+    "infrastructure",
+]
+
+result = {}
+
+for prefix in PREFIXES:
+    for path in Path("/ansible").glob(f"{prefix}-*.yml"):
+        name = path.with_suffix("").name[len(prefix) + 1 :]  # noqa E203
+        result[name] = prefix
+
+with open("/ansible/playbooks.yml", "w+") as fp:
+    fp.write(yaml.dump(result))


### PR DESCRIPTION
This script writes a list of all existing playbooks to /ansible/playbooks.yml.

Signed-off-by: Christian Berendt <berendt@osism.tech>