### PR TITLE
Symlink /etc/openstack -> /opt/configuration/environments/openstack

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -175,6 +175,9 @@ RUN cp -r /playbooks/playbooks/* /ansible \
     && mkdir -p /ansible/templates \
     && cp /playbooks/templates/* /ansible/templates
 
+# add symlink to /etc/openstack
+RUN ln -s /opt/configuration/environments/openstack /etc/openstack
+
 # copy ara configuration
 # hadolint ignore=DL3059
 RUN python3 -m ara.setup.env > /ansible/ara.env


### PR DESCRIPTION
Required to be able to create OpenStack resources e.g. via the infrastructure environment.