### PR TITLE
Unpin python-openstackclient

### DIFF
--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -23,8 +23,11 @@ osism=={{ osism_projects['osism'] }}
 paramiko==3.1.0
 PyMySQL==1.0.3
 python-dotenv==1.0.0
-python-openstackclient==6.2.0
 redis==4.5.4
 requests==2.29.0
 ruamel.yaml==0.17.21
 jxmlease==1.0.3
+
+# NOTE: Not pinned to avoid conflicts with the version of the
+#       OpenStack SDK in the osism package.
+python-openstackclient


### PR DESCRIPTION
Not pinned to avoid conflicts with the version of the OpenStack SDK in the osism package.