### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/bookwork-baf91af531f38a07.yaml
+++ b/releasenotes/notes/bookwork-baf91af531f38a07.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Use Debian Bookworm as base image.

--- a/releasenotes/notes/change-osism-7dc5424392e23fca.yaml
+++ b/releasenotes/notes/change-osism-7dc5424392e23fca.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the `change-osism.sh` script it is possible to install a different
-    python-osism version in a running inventory reconciler service.

--- a/releasenotes/notes/multistage-build-6f946104e5aedecb.yaml
+++ b/releasenotes/notes/multistage-build-6f946104e5aedecb.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Use multi-stage build.

--- a/releasenotes/notes/remove-json-stats-ansible-module-6b00ed67ca2f17aa.yaml
+++ b/releasenotes/notes/remove-json-stats-ansible-module-6b00ed67ca2f17aa.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    The json_stats Ansible module is no longer required by python-osism and has been removed.

--- a/releasenotes/notes/remove-mitogen-e22503786876215a.yaml
+++ b/releasenotes/notes/remove-mitogen-e22503786876215a.yaml
@@ -1,7 +1,0 @@
----
-upgrade:
-  - |
-    The Mitogen plugin was deprecated and has now been removed. It was no
-    longer usable with current Ansible versions and the upstream was not
-    very active. If the Mitogen plugin is used in a configuration repository
-    via the Ansible configuration, this must be removed respectively.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.