### PR TITLE
hardening: rename user_list to hardening_user_list

### DIFF
--- a/patches/hardening/use-hardening-user-list.patch
+++ b/patches/hardening/use-hardening-user-list.patch
@@ -1,0 +1,61 @@
+--- a/tasks/rhel7stig/accounts.yml
++++ b/tasks/rhel7stig/accounts.yml
+@@ -164,10 +164,10 @@
+   debug:
+     msg: >
+       The following users have GIDs in /etc/passwd that do not exist in /etc/group:
+-      {{ user_list.users | selectattr('group', 'equalto', False) | map(attribute='name') | join(', ') }}
++      {{ hardening_user_list.users | selectattr('group', 'equalto', False) | map(attribute='name') | join(', ') }}
+   when:
+-    - user_list is defined
+-    - user_list.users | selectattr('group', 'equalto', False) | list | length > 0
++    - hardening_user_list is defined
++    - hardening_user_list.users | selectattr('group', 'equalto', False) | list | length > 0
+   tags:
+     - accounts
+     - low
+@@ -200,10 +200,10 @@
+   debug:
+     msg: |
+       The following users do not have a home directory assigned:
+-      {{ user_list.users | selectattr('dir', 'equalto', '') | map(attribute='name') | join(', ') }}
++      {{ hardening_user_list.users | selectattr('dir', 'equalto', '') | map(attribute='name') | join(', ') }}
+   when:
+-    - user_list is defined
+-    - user_list.users | selectattr('dir', 'equalto', '') | map(attribute='name') | list | length > 0
++    - hardening_user_list is defined
++    - hardening_user_list.users | selectattr('dir', 'equalto', '') | map(attribute='name') | list | length > 0
+   tags:
+     - accounts
+     - medium
+@@ -214,7 +214,7 @@
+     path: "{{ item['dir'] }}"
+   when:
+     - item['dir'] | length > 0
+-  with_items: "{{ user_list.users }}"
++  with_items: "{{ hardening_user_list.users }}"
+   register: home_directory_checks
+   tags:
+     - accounts
+--- a/tasks/rhel7stig/file_perms.yml
++++ b/tasks/rhel7stig/file_perms.yml
+@@ -102,7 +102,7 @@
+     - item.uid >= 1000
+     - item.name != 'nobody'
+     - security_set_home_directory_permissions_and_owners | bool
+-  with_items: "{{ user_list.users | selectattr('uid', 'greaterthan', 999) | list }}"
++  with_items: "{{ hardening_user_list.users | selectattr('uid', 'greaterthan', 999) | list }}"
+   tags:
+     - medium
+     - file_perms
+--- a/tasks/rhel7stig/main.yml
++++ b/tasks/rhel7stig/main.yml
+@@ -40,7 +40,7 @@
+ - name: Get user data for all users on the system
+   get_users:
+     min_uid: 0
+-  register: user_list
++  register: hardening_user_list
+   check_mode: no
+   tags:
+     - always


### PR DESCRIPTION
The user_list parameter is an internal parameter in the ansible-hardening role. As we also use the user_list parameter in our own osism.commons.user role we rename the internal user_list parameter in the ansible-hardening role to hardening_user_list.

Closes osism/issues#1055