### PR TITLE
Ignore all Python UserWarnings

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -240,6 +240,8 @@ FROM python:3.12-slim-bookworm
 
 COPY --link --from=builder / /
 
+ENV PYTHONWARNINGS="ignore::UserWarning"
+
 VOLUME ["/ansible/secrets", "/ansible/logs", "/ansible/cache", "/share", "/archive", "/interface"]
 USER dragon
 WORKDIR /ansible


### PR DESCRIPTION
It looks like this is the only way to get rid of the CryptographyDeprecationWarning warnings.