### PR TITLE
Revert "renovate: manage files/src/requirements.txt"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,10 +3,5 @@
     "github>osism/renovate-config",
     "github>osism/renovate-config:docker",
     "github>osism/renovate-config:python"
-  ],
-  "pip_requirements": {
-    "fileMatch": [
-      "files/src/requirements.txt"
-     ]
-   }
+  ]
 }


### PR DESCRIPTION
Not required. Auto detection of Renovat works like expected.

This reverts commit 711767cc6d4bb4ce801054dd9c24b6d39e90c6d0.