### PR TITLE
Fix /ansible permissions

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -207,6 +207,8 @@ COPY --link --from=builder / /
 ENV PYTHONWARNINGS="ignore::UserWarning"
 
 VOLUME ["/ansible/secrets", "/ansible/logs", "/ansible/cache", "/share", "/archive", "/interface"]
-USER dragon
+
 WORKDIR /ansible
+RUN chown -R dragon: /ansible
+USER dragon
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Something in Docker 29.0.0 causes the WORKDIR to be owned by root as both owner and group. Previously, it was dragon. This change ensures that the WORKDIR is owned by dragon.