### PR TITLE
Use fast inventory directory when available

### DIFF
--- a/files/scripts/run-ansible.sh
+++ b/files/scripts/run-ansible.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-ceph.sh
+++ b/files/scripts/run-ceph.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-custom.sh
+++ b/files/scripts/run-custom.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-generic.sh
+++ b/files/scripts/run-generic.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-infrastructure.sh
+++ b/files/scripts/run-infrastructure.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-kolla.sh
+++ b/files/scripts/run-kolla.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-kubernetes.sh
+++ b/files/scripts/run-kubernetes.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-manager.sh
+++ b/files/scripts/run-manager.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-monitoring.sh
+++ b/files/scripts/run-monitoring.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-netbox.sh
+++ b/files/scripts/run-netbox.sh
@@ -21,7 +21,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$CONFIGURATION_DIRECTORY/$ENVIRONMENT/inventory/hosts.yml
+if [[ -d $CONFIGURATION_DIRECTORY/$ENVIRONMENT/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$CONFIGURATION_DIRECTORY/$ENVIRONMENT/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$CONFIGURATION_DIRECTORY/$ENVIRONMENT/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-openstack.sh
+++ b/files/scripts/run-openstack.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-proxmox.sh
+++ b/files/scripts/run-proxmox.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-state.sh
+++ b/files/scripts/run-state.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-validate.sh
+++ b/files/scripts/run-validate.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run-without-secrets.sh
+++ b/files/scripts/run-without-secrets.sh
@@ -23,7 +23,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then

--- a/files/scripts/run.sh
+++ b/files/scripts/run.sh
@@ -26,7 +26,11 @@ if [[ -e /ansible/ara.env ]]; then
     source /ansible/ara.env
 fi
 
-export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+if [[ -d $ANSIBLE_DIRECTORY/inventory/fast ]]; then
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/fast/
+else
+    export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+fi
 
 export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
 if [[ -e $ANSIBLE_DIRECTORY/inventory/ansible/ansible.cfg ]]; then


### PR DESCRIPTION
If /inventory/fast/ directory exists, use it as ANSIBLE_INVENTORY instead of /inventory/hosts.yml. This allows using a pre-built fast inventory while maintaining backward compatibility.

AI-assisted: Claude Code